### PR TITLE
feat: mcp-sdk -request cancelation & progress notifications

### DIFF
--- a/mcp-sdk/src/error.rs
+++ b/mcp-sdk/src/error.rs
@@ -26,6 +26,8 @@ pub enum MCPError {
     OutputTooLarge,
     #[error("Stream error: {0}")]
     StreamError(String),
+    #[error("Request was cancelled: {0}")]
+    RequestCancelled(String),
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
     #[error("JSON error: {0}")]
@@ -47,6 +49,7 @@ impl MCPError {
             MCPError::MethodNotFound(_) => (-32601, self.to_string()),
             MCPError::MissingParameters | MCPError::MissingToolName => (-32602, self.to_string()),
             MCPError::UnknownPrompt(_) | MCPError::UnknownResource(_) | MCPError::ResourceNotFound(_) => (-32602, self.to_string()),
+            MCPError::RequestCancelled(_) => (-32800, self.to_string()), // Custom cancellation code
             _ => (-32603, self.to_string()),
         };
         JsonRpcError { code, message, data: None }

--- a/mcp-sdk/src/lib.rs
+++ b/mcp-sdk/src/lib.rs
@@ -1,21 +1,20 @@
 pub mod error;
+pub mod notifications;
+pub mod prelude;
 pub mod request;
 pub mod response;
 pub mod server;
 pub mod tools;
-pub mod notifications;
 
 pub use error::MCPError;
+pub use notifications::{ProgressSender, ServerNotification};
 pub use request::MCPRequest;
 pub use response::MCPResponse;
-pub use server::{
-    JsonRpcVersion, ServerBuilder, SystemMCPServer, ToolHandler,
-};
+pub use server::{JsonRpcVersion, ServerBuilder, SystemMCPServer, ToolHandler};
 pub use tools::{
     CancellationNotification, CancellationNotificationMessage, CancellationParams,
     InitializeResponse, ProgressNotification, ProgressNotificationMessage, ProgressParams, Prompt,
     PromptArgument, PromptContent, PromptMessage, PromptResponse, Resource, ResourceContent,
     ServerCapabilities, ServerInfo, StreamChunk, Tool, ToolContent, ToolInputSchema, ToolProperty,
     ToolResponse,
-};
-pub use notifications::{ServerNotification, ProgressSender}; // ← NEW EXPORTS
+}; // ← NEW EXPORTS

--- a/mcp-sdk/src/lib.rs
+++ b/mcp-sdk/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod macros;
 pub mod notifications;
 pub mod prelude;
 pub mod request;

--- a/mcp-sdk/src/lib.rs
+++ b/mcp-sdk/src/lib.rs
@@ -1,15 +1,21 @@
 pub mod error;
 pub mod request;
 pub mod response;
-pub mod tools;
 pub mod server;
+pub mod tools;
+pub mod notifications;
 
 pub use error::MCPError;
 pub use request::MCPRequest;
 pub use response::MCPResponse;
-pub use tools::{
-    Tool, ToolContent, ToolResponse, ServerCapabilities, InitializeResponse, ServerInfo,
-    ToolInputSchema, ToolProperty, Prompt, PromptArgument, PromptResponse, PromptMessage,
-    PromptContent, Resource, ResourceContent, StreamChunk
+pub use server::{
+    JsonRpcVersion, ServerBuilder, SystemMCPServer, ToolHandler,
 };
-pub use server::{SystemMCPServer, ServerBuilder, ToolHandler, JsonRpcVersion};
+pub use tools::{
+    CancellationNotification, CancellationNotificationMessage, CancellationParams,
+    InitializeResponse, ProgressNotification, ProgressNotificationMessage, ProgressParams, Prompt,
+    PromptArgument, PromptContent, PromptMessage, PromptResponse, Resource, ResourceContent,
+    ServerCapabilities, ServerInfo, StreamChunk, Tool, ToolContent, ToolInputSchema, ToolProperty,
+    ToolResponse,
+};
+pub use notifications::{ServerNotification, ProgressSender}; // ← NEW EXPORTS

--- a/mcp-sdk/src/macros.rs
+++ b/mcp-sdk/src/macros.rs
@@ -24,9 +24,40 @@ macro_rules! tool_dispatch {
 /// Helper macro for extracting required parameters from JSON args
 #[macro_export]
 macro_rules! extract_required {
-    ($args:expr, $key:expr, $type:ty) => {
+    // String
+    ($args:expr, $key:expr, String) => {
         $args.get($key)
-            .and_then(|v| <$type>::try_from(v).ok())
+            .and_then(|v| v.as_str().map(|s| s.to_owned()))
+            .ok_or($crate::MCPError::MissingParameters)?
+    };
+    // &str (returns String for convenience)
+    ($args:expr, $key:expr, &str) => {
+        $args.get($key)
+            .and_then(|v| v.as_str().map(|s| s.to_owned()))
+            .ok_or($crate::MCPError::MissingParameters)?
+    };
+    // i64
+    ($args:expr, $key:expr, i64) => {
+        $args.get($key)
+            .and_then(|v| v.as_i64())
+            .ok_or($crate::MCPError::MissingParameters)?
+    };
+    // u64
+    ($args:expr, $key:expr, u64) => {
+        $args.get($key)
+            .and_then(|v| v.as_u64())
+            .ok_or($crate::MCPError::MissingParameters)?
+    };
+    // f64
+    ($args:expr, $key:expr, f64) => {
+        $args.get($key)
+            .and_then(|v| v.as_f64())
+            .ok_or($crate::MCPError::MissingParameters)?
+    };
+    // bool
+    ($args:expr, $key:expr, bool) => {
+        $args.get($key)
+            .and_then(|v| v.as_bool())
             .ok_or($crate::MCPError::MissingParameters)?
     };
 }
@@ -34,9 +65,40 @@ macro_rules! extract_required {
 /// Helper macro for extracting optional parameters with defaults
 #[macro_export]
 macro_rules! extract_optional {
-    ($args:expr, $key:expr, $type:ty, $default:expr) => {
+    // String
+    ($args:expr, $key:expr, String, $default:expr) => {
         $args.get($key)
-            .and_then(|v| <$type>::try_from(v).ok())
+            .and_then(|v| v.as_str().map(|s| s.to_owned()))
+            .unwrap_or($default)
+    };
+    // &str (returns String for convenience)
+    ($args:expr, $key:expr, &str, $default:expr) => {
+        $args.get($key)
+            .and_then(|v| v.as_str().map(|s| s.to_owned()))
+            .unwrap_or($default)
+    };
+    // i64
+    ($args:expr, $key:expr, i64, $default:expr) => {
+        $args.get($key)
+            .and_then(|v| v.as_i64())
+            .unwrap_or($default)
+    };
+    // u64
+    ($args:expr, $key:expr, u64, $default:expr) => {
+        $args.get($key)
+            .and_then(|v| v.as_u64())
+            .unwrap_or($default)
+    };
+    // f64
+    ($args:expr, $key:expr, f64, $default:expr) => {
+        $args.get($key)
+            .and_then(|v| v.as_f64())
+            .unwrap_or($default)
+    };
+    // bool
+    ($args:expr, $key:expr, bool, $default:expr) => {
+        $args.get($key)
+            .and_then(|v| v.as_bool())
             .unwrap_or($default)
     };
 }

--- a/mcp-sdk/src/macros.rs
+++ b/mcp-sdk/src/macros.rs
@@ -1,3 +1,12 @@
+/// Dispatches tool calls to handler methods based on tool name
+///
+/// # Example
+/// ```
+/// tool_dispatch!(self, name, args, progress_sender, {
+///     "run_command" => handle_run_command,
+///     "list_directory" => handle_list_directory,
+/// })
+/// ```
 #[macro_export]
 macro_rules! tool_dispatch {
     ($self:ident, $name:expr, $args:expr, $sender:expr, {
@@ -9,5 +18,25 @@ macro_rules! tool_dispatch {
             )*
             _ => Err($crate::MCPError::UnknownTool($name.into())),
         }
+    };
+}
+
+/// Helper macro for extracting required parameters from JSON args
+#[macro_export]
+macro_rules! extract_required {
+    ($args:expr, $key:expr, $type:ty) => {
+        $args.get($key)
+            .and_then(|v| <$type>::try_from(v).ok())
+            .ok_or($crate::MCPError::MissingParameters)?
+    };
+}
+
+/// Helper macro for extracting optional parameters with defaults
+#[macro_export]
+macro_rules! extract_optional {
+    ($args:expr, $key:expr, $type:ty, $default:expr) => {
+        $args.get($key)
+            .and_then(|v| <$type>::try_from(v).ok())
+            .unwrap_or($default)
     };
 }

--- a/mcp-sdk/src/macros.rs
+++ b/mcp-sdk/src/macros.rs
@@ -1,0 +1,13 @@
+#[macro_export]
+macro_rules! tool_dispatch {
+    ($self:ident, $name:expr, $args:expr, $sender:expr, {
+        $($key:expr => $method:ident),* $(,)?
+    }) => {
+        match $name {
+            $(
+                $key => $self.$method($args, $sender).await,
+            )*
+            _ => Err($crate::MCPError::UnknownTool($name.into())),
+        }
+    };
+}

--- a/mcp-sdk/src/notifications.rs
+++ b/mcp-sdk/src/notifications.rs
@@ -23,12 +23,12 @@ impl ProgressSender {
     }
 
     /// Send a progress notification
-    pub async fn send_progress(&self, request_id: &str, progress: f64, message: Option<String>) {
+    pub async fn send_progress(&self, request_id: &str, progress: f64, message: Option<String>) -> Result<(), mpsc::error::SendError<ServerNotification>> {
         let notification = ServerNotification::Progress {
             request_id: request_id.to_string(),
             progress,
             message,
         };
-        let _ = self.sender.send(notification);
+        self.sender.send(notification)
     }
 }

--- a/mcp-sdk/src/notifications.rs
+++ b/mcp-sdk/src/notifications.rs
@@ -1,0 +1,34 @@
+use tokio::sync::mpsc;
+
+/// Notification types for multiplexed output
+#[derive(Debug, Clone)]
+pub enum ServerNotification {
+    Progress {
+        request_id: String,
+        progress: f64,
+        message: Option<String>,
+    },
+}
+
+/// Progress sender for handlers to use
+#[derive(Debug, Clone)]
+pub struct ProgressSender {
+    sender: mpsc::UnboundedSender<ServerNotification>,
+}
+
+impl ProgressSender {
+    /// Create a new progress sender from an unbounded channel sender
+    pub fn new(sender: mpsc::UnboundedSender<ServerNotification>) -> Self {
+        Self { sender }
+    }
+
+    /// Send a progress notification
+    pub async fn send_progress(&self, request_id: &str, progress: f64, message: Option<String>) {
+        let notification = ServerNotification::Progress {
+            request_id: request_id.to_string(),
+            progress,
+            message,
+        };
+        let _ = self.sender.send(notification);
+    }
+}

--- a/mcp-sdk/src/prelude.rs
+++ b/mcp-sdk/src/prelude.rs
@@ -1,0 +1,5 @@
+pub use crate::{
+    MCPError, MCPRequest, MCPResponse,
+    ToolHandler, ProgressSender,
+    Tool, ToolResponse,
+};

--- a/mcp-sdk/src/server.rs
+++ b/mcp-sdk/src/server.rs
@@ -1,7 +1,7 @@
 use crate::error::MCPError;
 use crate::request::MCPRequest;
 use crate::response::MCPResponse;
-use crate::notifications::{ServerNotification, ProgressSender}; // ← NEW IMPORT
+use crate::notifications::{ServerNotification, ProgressSender};
 use crate::tools::{
     InitializeResponse, Prompt, PromptResponse, Resource, ResourceContent,
     ServerCapabilities, ServerInfo, StreamChunk, Tool, ToolResponse

--- a/mcp-sdk/src/server.rs
+++ b/mcp-sdk/src/server.rs
@@ -14,8 +14,6 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
 use tokio_stream::Stream;
 
-// ← REMOVED: ServerNotification and ProgressSender definitions (now in notifications.rs)
-
 #[async_trait]
 pub trait ToolHandler: Send + Sync {
     // Tool methods

--- a/mcp-sdk/src/server.rs
+++ b/mcp-sdk/src/server.rs
@@ -273,7 +273,7 @@ impl<H: ToolHandler> SystemMCPServer<H> {
         }
 
         // Create progress sender for this request
-        let progress_sender = ProgressSender::new(self.notification_tx.clone()); // ← UPDATED
+        let progress_sender = ProgressSender::new(self.notification_tx.clone());
 
         // Execute with cancellation support
         let result = tokio::select! {

--- a/mcp-sdk/src/server.rs
+++ b/mcp-sdk/src/server.rs
@@ -186,7 +186,7 @@ impl<H: ToolHandler> SystemMCPServer<H> {
                     capabilities: self.capabilities.clone(),
                     server_info: ServerInfo {
                         name: "secure-system-mcp".into(),
-                        version: "0.5.0".into(),
+                        version: env!("CARGO_PKG_VERSION").into(),
                     },
                 }).map_err(MCPError::from)
             }

--- a/mcp-sdk/src/server.rs
+++ b/mcp-sdk/src/server.rs
@@ -1,19 +1,25 @@
-use async_trait::async_trait;
-use tokio_stream::Stream;
 use crate::error::MCPError;
 use crate::request::MCPRequest;
 use crate::response::MCPResponse;
+use crate::notifications::{ServerNotification, ProgressSender}; // ← NEW IMPORT
 use crate::tools::{
-    InitializeResponse, ServerCapabilities, ServerInfo, Tool, ToolResponse,
-    Prompt, PromptResponse, Resource, ResourceContent, StreamChunk
+    InitializeResponse, Prompt, PromptResponse, Resource, ResourceContent,
+    ServerCapabilities, ServerInfo, StreamChunk, Tool, ToolResponse
 };
+use async_trait::async_trait;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+use tokio_stream::Stream;
+
+// ← REMOVED: ServerNotification and ProgressSender definitions (now in notifications.rs)
 
 #[async_trait]
 pub trait ToolHandler: Send + Sync {
     // Tool methods
-    async fn call_tool(&self, name: &str, args: &Value) -> Result<ToolResponse, MCPError>;
+    async fn call_tool(&self, name: &str, args: &Value, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError>;
 
     // Prompt methods
     async fn list_prompts(&self) -> Result<Vec<Prompt>, MCPError> {
@@ -47,6 +53,11 @@ pub trait ToolHandler: Send + Sync {
 
     async fn on_tool_completed(&self, name: &str, success: bool) {
         let _ = (name, success);
+    }
+
+    // Cancellation hook
+    async fn on_request_cancelled(&self, request_id: &str, reason: Option<&str>) {
+        eprintln!("[CANCEL] Request {} cancelled: {:?}", request_id, reason);
     }
 }
 
@@ -102,9 +113,13 @@ impl ServerBuilder {
     }
 
     pub fn build<H: ToolHandler>(self, handler: H) -> SystemMCPServer<H> {
+        let (notification_tx, notification_rx) = mpsc::unbounded_channel();
         SystemMCPServer {
             handler,
             capabilities: self.capabilities,
+            active_requests: Arc::new(RwLock::new(HashMap::new())),
+            notification_tx,
+            notification_rx: Some(notification_rx),
         }
     }
 }
@@ -112,11 +127,20 @@ impl ServerBuilder {
 pub struct SystemMCPServer<H: ToolHandler> {
     handler: H,
     capabilities: ServerCapabilities,
+    // Track in-progress requests for cancellation
+    active_requests: Arc<RwLock<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    // Notification channel for progress updates
+    notification_tx: mpsc::UnboundedSender<ServerNotification>,
+    notification_rx: Option<mpsc::UnboundedReceiver<ServerNotification>>,
 }
 
 impl<H: ToolHandler> SystemMCPServer<H> {
     pub fn builder() -> ServerBuilder {
         ServerBuilder::new()
+    }
+
+    pub fn take_notification_receiver(&mut self) -> Option<mpsc::UnboundedReceiver<ServerNotification>> {
+        self.notification_rx.take()
     }
 
     fn detect_version(&self, req: &MCPRequest) -> JsonRpcVersion {
@@ -142,8 +166,19 @@ impl<H: ToolHandler> SystemMCPServer<H> {
     pub async fn handle(&self, req: MCPRequest) -> Option<MCPResponse> {
         let version = self.detect_version(&req);
 
+        // Handle notifications (no response)
         if req.id.is_none() {
-            return None;
+            return match req.method.as_str() {
+                "notifications/cancelled" => {
+                    self.handle_cancellation(&req).await;
+                    None
+                }
+                "notifications/ping" => {
+                    eprintln!("[PING] Received ping from client");
+                    None
+                }
+                _ => None,
+            }
         }
 
         let result: Result<Value, MCPError> = match req.method.as_str() {
@@ -153,20 +188,16 @@ impl<H: ToolHandler> SystemMCPServer<H> {
                     capabilities: self.capabilities.clone(),
                     server_info: ServerInfo {
                         name: "secure-system-mcp".into(),
-                        version: "0.3.0".into(), // Updated version
+                        version: "0.5.0".into(),
                     },
                 }).map_err(MCPError::from)
             }
-
             "tools/list" => Ok(self.list_tools()),
-            "tools/call" => self.handle_tool_call(&req).await,
-
+            "tools/call" => self.handle_tool_call_with_cancellation(&req).await,
             "prompts/list" => Ok(self.list_prompts()),
             "prompts/get" => self.handle_prompt_get(&req).await,
-
             "resources/list" => Ok(self.list_resources()),
             "resources/read" => self.handle_resource_read(&req).await,
-
             other => Err(MCPError::MethodNotFound(other.into())),
         };
 
@@ -210,14 +241,69 @@ impl<H: ToolHandler> SystemMCPServer<H> {
         }
     }
 
-    async fn handle_tool_call(&self, req: &MCPRequest) -> Result<Value, MCPError> {
+    async fn handle_cancellation(&self, req: &MCPRequest) {
+        if let Some(params) = &req.params {
+            if let Some(request_id) = params.get("requestId").and_then(Value::as_str) {
+                let reason = params.get("reason").and_then(Value::as_str);
+
+                // Signal cancellation to active request
+                {
+                    let mut active = self.active_requests.write().await;
+                    if let Some(cancel_tx) = active.remove(request_id) {
+                        let _ = cancel_tx.send(());
+                        eprintln!("[CANCEL] Request {} cancelled: {:?}", request_id, reason);
+
+                        // Notify handler
+                        self.handler.on_request_cancelled(request_id, reason).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_tool_call_with_cancellation(&self, req: &MCPRequest) -> Result<Value, MCPError> {
+        let request_id = req.id.as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+
+        // Register cancellation handler
+        {
+            let mut active = self.active_requests.write().await;
+            active.insert(request_id.clone(), cancel_tx);
+        }
+
+        // Create progress sender for this request
+        let progress_sender = ProgressSender::new(self.notification_tx.clone()); // ← UPDATED
+
+        // Execute with cancellation support
+        let result = tokio::select! {
+            result = self.handle_tool_call(req, progress_sender) => {
+                result
+            }
+            _ = cancel_rx => {
+                eprintln!("[CANCEL] Tool call {} was cancelled", request_id);
+                Err(MCPError::RequestCancelled(request_id.clone()))
+            }
+        };
+
+        // Clean up
+        {
+            let mut active = self.active_requests.write().await;
+            active.remove(&request_id);
+        }
+
+        result
+    }
+
+    async fn handle_tool_call(&self, req: &MCPRequest, progress_sender: ProgressSender) -> Result<Value, MCPError> {
         match (req.params.as_ref(), req.params.as_ref().and_then(|p| p.get("name")).and_then(Value::as_str)) {
             (Some(params), Some(name)) => {
                 let args = params.get("arguments").unwrap_or(&Value::Null);
 
                 self.handler.on_tool_called(name).await;
-
-                let result = self.handler.call_tool(name, args).await;
+                let result = self.handler.call_tool(name, args, progress_sender).await;
                 let success = result.is_ok();
                 self.handler.on_tool_completed(name, success).await;
 

--- a/mcp-sdk/src/tools.rs
+++ b/mcp-sdk/src/tools.rs
@@ -27,6 +27,89 @@ impl ToolResponse {
     }
 }
 
+/// Progress notification for long-running operations
+#[derive(Debug, Serialize, Clone)]
+pub struct ProgressNotification {
+    #[serde(rename = "requestId")]
+    pub request_id: String,
+    pub progress: f64, // 0.0 to 1.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// Cancellation notification
+#[derive(Debug, Serialize, Clone)]
+pub struct CancellationNotification {
+    #[serde(rename = "requestId")]
+    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// JSON-RPC progress notification message (MCP protocol compliant)
+#[derive(Debug, Serialize, Clone)]
+pub struct ProgressNotificationMessage {
+    pub jsonrpc: String,
+    pub method: String,
+    pub params: ProgressParams,
+}
+
+/// Parameters for progress notifications
+#[derive(Debug, Serialize, Clone)]
+pub struct ProgressParams {
+    #[serde(rename = "requestId")]
+    pub request_id: String,
+    pub progress: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl ProgressNotificationMessage {
+    /// Create a new progress notification message
+    pub fn new(request_id: String, progress: f64, message: Option<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            method: "notifications/progress".into(),
+            params: ProgressParams {
+                request_id,
+                progress,
+                message,
+            },
+        }
+    }
+}
+
+/// JSON-RPC cancellation notification message (MCP protocol compliant)
+#[derive(Debug, Serialize, Clone)]
+pub struct CancellationNotificationMessage {
+    pub jsonrpc: String,
+    pub method: String,
+    pub params: CancellationParams,
+}
+
+/// Parameters for cancellation notifications
+#[derive(Debug, Serialize, Clone)]
+pub struct CancellationParams {
+    #[serde(rename = "requestId")]
+    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl CancellationNotificationMessage {
+    /// Create a new cancellation notification message
+    pub fn new(request_id: String, reason: Option<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            method: "notifications/cancelled".into(),
+            params: CancellationParams {
+                request_id,
+                reason,
+            },
+        }
+    }
+}
+
 /// Prompt definition with parameters
 #[derive(Debug, Serialize, Clone)]
 pub struct Prompt {

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,19 +237,17 @@ impl MyToolHandler {
 
     async fn handle_get_system_info(
         &self,
-        args: &Value,
+        _args: &Value,
         progress_sender: ProgressSender,
     ) -> Result<ToolResponse, MCPError> {
-        let _ = args; // No parameters needed
         self.get_system_info(progress_sender).await
     }
 
     async fn handle_long_running_task(
         &self,
-        args: &Value,
+        _args: &Value,
         progress_sender: ProgressSender,
     ) -> Result<ToolResponse, MCPError> {
-        let _ = args; // No parameters needed
         self.long_running_task(progress_sender).await
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,17 @@
 use async_trait::async_trait;
 use mcp_sdk::{
-    tools::{Tool, ToolInputSchema, ToolProperty, ToolResponse, Prompt, PromptArgument,
-            PromptResponse, PromptMessage, PromptContent, Resource, ResourceContent,
-            ProgressNotificationMessage}, // Import the SDK progress types
-    MCPRequest, MCPResponse, ServerBuilder, ToolHandler, MCPError,
-    ProgressSender, ServerNotification
+    MCPError, MCPRequest, MCPResponse, ProgressSender, ServerBuilder, ServerNotification,
+    ToolHandler, tool_dispatch,
+    tools::{
+        ProgressNotificationMessage, Prompt, PromptArgument, PromptContent, PromptMessage,
+        PromptResponse, Resource, ResourceContent, Tool, ToolInputSchema, ToolProperty,
+        ToolResponse,
+    },
 };
+use serde_json::Value;
 use std::io::{self, BufRead, Write};
 use tokio::process::Command;
-use tokio::time::{timeout, Duration};
-use serde_json::Value;
+use tokio::time::{Duration, timeout};
 
 const MAX_REQUEST_SIZE: usize = 1024 * 1024;
 const MAX_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
@@ -19,70 +21,62 @@ struct MyToolHandler;
 
 #[async_trait]
 impl ToolHandler for MyToolHandler {
-    async fn call_tool(&self, name: &str, args: &Value, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
-        match name {
-            "run_command" => {
-                let command = args.get("command").and_then(Value::as_str).ok_or(MCPError::MissingParameters)?;
-                let argv = args.get("args").and_then(Value::as_array).map(|arr| {
-                    arr.iter().filter_map(Value::as_str).map(String::from).collect()
-                }).unwrap_or_default();
-                let _token = args.get("token").and_then(Value::as_str).ok_or(MCPError::MissingParameters)?;
-                self.run_command(command, argv, progress_sender).await
-            }
-            "list_directory" => {
-                let path = args.get("path").and_then(Value::as_str).unwrap_or(".");
-                let show_hidden = args.get("show_hidden").and_then(Value::as_bool).unwrap_or(false);
-                self.list_directory(path, show_hidden, progress_sender).await
-            }
-            "read_file" => {
-                let path = args.get("path").and_then(Value::as_str).ok_or(MCPError::MissingParameters)?;
-                let lines = args.get("lines").and_then(Value::as_str);
-                self.read_file(path, lines, progress_sender).await
-            }
-            "get_system_info" => {
-                self.get_system_info(progress_sender).await
-            }
-            "long_running_task" => {
-                self.long_running_task(progress_sender).await
-            }
-            _ => Err(MCPError::UnknownTool(name.into())),
-        }
+    async fn call_tool(
+        &self,
+        name: &str,
+        args: &Value,
+        progress_sender: ProgressSender,
+    ) -> Result<ToolResponse, MCPError> {
+        tool_dispatch!(self, name, args, progress_sender, {
+            "run_command" => handle_run_command,
+            "list_directory" => handle_list_directory,
+            "read_file" => handle_read_file,
+            "get_system_info" => handle_get_system_info,
+            "long_running_task" => handle_long_running_task,
+        })
     }
 
     async fn list_prompts(&self) -> Result<Vec<Prompt>, MCPError> {
         Ok(vec![
-            Prompt::new("system_analysis", "Analyze system performance and health")
-                .with_arguments(vec![
+            Prompt::new("system_analysis", "Analyze system performance and health").with_arguments(
+                vec![
                     PromptArgument::new("component", "System component to analyze", false),
                     PromptArgument::new("depth", "Analysis depth level", false),
-                ]),
-            Prompt::new("command_generator", "Generate safe system commands")
-                .with_arguments(vec![
-                    PromptArgument::new("task", "Task description", true),
-                    PromptArgument::new("safety_level", "Safety level (high/medium/low)", false),
-                ]),
+                ],
+            ),
+            Prompt::new("command_generator", "Generate safe system commands").with_arguments(vec![
+                PromptArgument::new("task", "Task description", true),
+                PromptArgument::new("safety_level", "Safety level (high/medium/low)", false),
+            ]),
         ])
     }
 
     async fn get_prompt(&self, name: &str, args: &Value) -> Result<PromptResponse, MCPError> {
         match name {
             "system_analysis" => {
-                let component = args.get("component").and_then(Value::as_str).unwrap_or("overall");
+                let component = args
+                    .get("component")
+                    .and_then(Value::as_str)
+                    .unwrap_or("overall");
                 Ok(PromptResponse {
                     description: format!("System analysis prompt for {}", component),
-                    messages: vec![
-                        PromptMessage {
-                            role: "user".into(),
-                            content: PromptContent {
-                                content_type: "text".into(),
-                                text: format!("Please analyze the {} system component. Provide detailed insights on performance, health, and recommendations.", component),
-                            },
-                        }
-                    ],
+                    messages: vec![PromptMessage {
+                        role: "user".into(),
+                        content: PromptContent {
+                            content_type: "text".into(),
+                            text: format!(
+                                "Please analyze the {} system component. Provide detailed insights on performance, health, and recommendations.",
+                                component
+                            ),
+                        },
+                    }],
                 })
             }
             "command_generator" => {
-                let task = args.get("task").and_then(Value::as_str).ok_or(MCPError::MissingParameters)?;
+                let task = args
+                    .get("task")
+                    .and_then(Value::as_str)
+                    .ok_or(MCPError::MissingParameters)?;
                 Ok(PromptResponse {
                     description: "Command generation prompt".into(),
                     messages: vec![
@@ -124,7 +118,9 @@ impl ToolHandler for MyToolHandler {
     async fn read_resource(&self, uri: &str) -> Result<ResourceContent, MCPError> {
         match uri {
             "file:///etc/os-release" => {
-                let content = tokio::fs::read_to_string("/etc/os-release").await.map_err(MCPError::IoError)?;
+                let content = tokio::fs::read_to_string("/etc/os-release")
+                    .await
+                    .map_err(MCPError::IoError)?;
                 Ok(ResourceContent {
                     uri: uri.into(),
                     mime_type: "text/plain".into(),
@@ -132,7 +128,9 @@ impl ToolHandler for MyToolHandler {
                 })
             }
             "file:///proc/meminfo" => {
-                let content = tokio::fs::read_to_string("/proc/meminfo").await.map_err(MCPError::IoError)?;
+                let content = tokio::fs::read_to_string("/proc/meminfo")
+                    .await
+                    .map_err(MCPError::IoError)?;
                 Ok(ResourceContent {
                     uri: uri.into(),
                     mime_type: "text/plain".into(),
@@ -172,13 +170,61 @@ impl ToolHandler for MyToolHandler {
 }
 
 impl MyToolHandler {
-    async fn run_command(&self, command: &str, args: Vec<String>, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
-        progress_sender.send_progress("cmd", 0.0, Some("Starting command execution".into())).await;
+    async fn handle_run_command(&self, args: &Value, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+        let command = args.get("command").and_then(Value::as_str).ok_or(MCPError::MissingParameters)?;
+        let argv = args.get("args").and_then(Value::as_array)
+            .map(|arr| arr.iter().filter_map(Value::as_str).map(String::from).collect())
+            .unwrap_or_default();
+        let _token = args.get("token").and_then(Value::as_str).ok_or(MCPError::MissingParameters)?;
 
-        let output = timeout(MAX_COMMAND_TIMEOUT, Command::new(command).args(&args).output())
-            .await.map_err(|_| MCPError::CommandTimeout)??;
+        self.run_command(command, argv, progress_sender).await
+    }
 
-        progress_sender.send_progress("cmd", 1.0, Some("Command completed".into())).await;
+    async fn handle_list_directory(&self, args: &Value, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+        let path = args.get("path").and_then(Value::as_str).unwrap_or(".");
+        let show_hidden = args.get("show_hidden").and_then(Value::as_bool).unwrap_or(false);
+
+        self.list_directory(path, show_hidden, progress_sender).await
+    }
+
+    async fn handle_read_file(&self, args: &Value, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+        let path = args.get("path").and_then(Value::as_str).ok_or(MCPError::MissingParameters)?;
+        let lines = args.get("lines").and_then(Value::as_str);
+
+        self.read_file(path, lines, progress_sender).await
+    }
+
+    async fn handle_get_system_info(&self, args: &Value, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+        let _ = args; // Unused for this method
+        self.get_system_info(progress_sender).await
+    }
+
+    async fn handle_long_running_task(&self, args: &Value, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+        let _ = args; // Unused for this method
+        self.long_running_task(progress_sender).await
+    }
+
+    // ✅ EXISTING: Original implementation methods (unchanged)
+    async fn run_command(
+        &self,
+        command: &str,
+        args: Vec<String>,
+        progress_sender: ProgressSender,
+    ) -> Result<ToolResponse, MCPError> {
+        progress_sender
+            .send_progress("cmd", 0.0, Some("Starting command execution".into()))
+            .await;
+
+        let output = timeout(
+            MAX_COMMAND_TIMEOUT,
+            Command::new(command).args(&args).output(),
+        )
+            .await
+            .map_err(|_| MCPError::CommandTimeout)??;
+
+        progress_sender
+            .send_progress("cmd", 1.0, Some("Command completed".into()))
+            .await;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -190,24 +236,52 @@ impl MyToolHandler {
 
         let text = format!(
             "Command: {} {}\nSuccess: {}\n\nStdout:\n{}{}",
-            command, args.join(" "), success, stdout,
-            if stderr.is_empty() { String::new() } else { format!("\nStderr:\n{}", stderr) }
+            command,
+            args.join(" "),
+            success,
+            stdout,
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!("\nStderr:\n{}", stderr)
+            }
         );
 
         Ok(ToolResponse::new(text, !success))
     }
 
-    async fn list_directory(&self, path: &str, show_hidden: bool, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+    async fn list_directory(
+        &self,
+        path: &str,
+        show_hidden: bool,
+        progress_sender: ProgressSender,
+    ) -> Result<ToolResponse, MCPError> {
         let flag = if show_hidden { "-la" } else { "-l" };
-        self.run_command("ls", vec![flag.to_string(), path.to_string()], progress_sender).await
+        self.run_command(
+            "ls",
+            vec![flag.to_string(), path.to_string()],
+            progress_sender,
+        )
+            .await
     }
 
-    async fn read_file(&self, path: &str, lines: Option<&str>, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+    async fn read_file(
+        &self,
+        path: &str,
+        lines: Option<&str>,
+        progress_sender: ProgressSender,
+    ) -> Result<ToolResponse, MCPError> {
         let (cmd, args) = if let Some(n) = lines {
             if let Ok(n) = n.parse::<u32>() {
-                ("head", vec!["-n".to_string(), n.to_string(), path.to_string()])
+                (
+                    "head",
+                    vec!["-n".to_string(), n.to_string(), path.to_string()],
+                )
             } else if n.starts_with('-') && n[1..].parse::<u32>().is_ok() {
-                ("tail", vec!["-n".to_string(), n[1..].to_string(), path.to_string()])
+                (
+                    "tail",
+                    vec!["-n".to_string(), n[1..].to_string(), path.to_string()],
+                )
             } else {
                 ("cat", vec![path.to_string()])
             }
@@ -217,7 +291,10 @@ impl MyToolHandler {
         self.run_command(cmd, args, progress_sender).await
     }
 
-    async fn get_system_info(&self, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+    async fn get_system_info(
+        &self,
+        progress_sender: ProgressSender,
+    ) -> Result<ToolResponse, MCPError> {
         let cmds = [
             ("uname", vec!["-a"]),
             ("whoami", vec![]),
@@ -231,10 +308,17 @@ impl MyToolHandler {
 
         for (i, (cmd, args)) in cmds.iter().enumerate() {
             let progress = (i as f64) / (total_cmds as f64);
-            progress_sender.send_progress("sysinfo", progress, Some(format!("Running {}", cmd))).await;
+            progress_sender
+                .send_progress("sysinfo", progress, Some(format!("Running {}", cmd)))
+                .await;
 
             let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-            match timeout(Duration::from_secs(5), Command::new(cmd).args(&args).output()).await {
+            match timeout(
+                Duration::from_secs(5),
+                Command::new(cmd).args(&args).output(),
+            )
+                .await
+            {
                 Ok(Ok(output)) => {
                     let stdout = String::from_utf8_lossy(&output.stdout);
                     lines.push(format!("{}: {}", cmd, stdout.trim()));
@@ -243,22 +327,40 @@ impl MyToolHandler {
             }
         }
 
-        progress_sender.send_progress("sysinfo", 1.0, Some("System info collection complete".into())).await;
+        progress_sender
+            .send_progress(
+                "sysinfo",
+                1.0,
+                Some("System info collection complete".into()),
+            )
+            .await;
 
         let text = format!("System Information:\n{}", lines.join("\n"));
         Ok(ToolResponse::new(text, false))
     }
 
-    async fn long_running_task(&self, progress_sender: ProgressSender) -> Result<ToolResponse, MCPError> {
+    async fn long_running_task(
+        &self,
+        progress_sender: ProgressSender,
+    ) -> Result<ToolResponse, MCPError> {
         eprintln!("[TASK] Starting long-running task with progress notifications...");
 
         for i in 1..=10 {
             tokio::time::sleep(Duration::from_millis(500)).await;
             let progress = i as f64 / 10.0;
-            progress_sender.send_progress("longtask", progress, Some(format!("Processing step {} of 10", i))).await;
+            progress_sender
+                .send_progress(
+                    "longtask",
+                    progress,
+                    Some(format!("Processing step {} of 10", i)),
+                )
+                .await;
         }
 
-        Ok(ToolResponse::new("Long-running task completed successfully with progress notifications".into(), false))
+        Ok(ToolResponse::new(
+            "Long-running task completed successfully with progress notifications".into(),
+            false,
+        ))
     }
 }
 
@@ -278,7 +380,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 properties: {
                     let mut props = std::collections::HashMap::new();
                     props.insert("command".into(), ToolProperty::string("Command to run"));
-                    props.insert("args".into(), ToolProperty::array("Command arguments", "string"));
+                    props.insert(
+                        "args".into(),
+                        ToolProperty::array("Command arguments", "string"),
+                    );
                     props.insert("token".into(), ToolProperty::string("Security token"));
                     props
                 },
@@ -293,7 +398,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 properties: {
                     let mut props = std::collections::HashMap::new();
                     props.insert("path".into(), ToolProperty::string("Directory path"));
-                    props.insert("show_hidden".into(), ToolProperty::boolean("Include hidden files", false));
+                    props.insert(
+                        "show_hidden".into(),
+                        ToolProperty::boolean("Include hidden files", false),
+                    );
                     props
                 },
                 required: vec![],
@@ -356,13 +464,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Take the notification receiver for multiplexed output
     let mut notification_rx = server.take_notification_receiver().unwrap();
 
-    // ✅ FIXED: Handle progress notifications in a separate task
+    // Handle progress notifications in a separate task
     let notification_task = tokio::spawn(async move {
         while let Some(notification) = notification_rx.recv().await {
             match notification {
-                ServerNotification::Progress { request_id, progress, message } => {
-                    let notification_msg = ProgressNotificationMessage::new(request_id, progress, message);
-
+                ServerNotification::Progress {
+                    request_id,
+                    progress,
+                    message,
+                } => {
+                    let notification_msg =
+                        ProgressNotificationMessage::new(request_id, progress, message);
                     if let Ok(json) = serde_json::to_string(&notification_msg) {
                         println!("{}", json);
                         let _ = io::stdout().flush();
@@ -372,11 +484,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    // ✅ FIXED: Use blocking stdin reading without spawning
+    // Process requests on main thread
     let stdin = io::stdin();
     let mut stdout = io::stdout();
 
-    // Process requests on main thread to avoid Send issues
     for line in stdin.lock().lines() {
         let raw = match line {
             Ok(raw) => raw,


### PR DESCRIPTION
This pull request introduces significant improvements to the MCP SDK to support robust request cancellation and progress notification for long-running tool calls. The changes include new notification types, protocol-compliant message structures, handler hooks for cancellation, and ergonomic macros for tool dispatch and parameter extraction. These updates enhance the SDK's extensibility and usability for both implementers and clients.

**Major features and improvements:**

### Request Cancellation and Progress Notification

* Added support for request cancellation: the server now tracks active requests and allows clients to cancel them via a new `"notifications/cancelled"` notification, with proper cleanup and handler hooks (`on_request_cancelled`). A new `MCPError::RequestCancelled` variant and JSON-RPC error code are introduced for cancelled requests. [[1]](diffhunk://#diff-bbc9bd62ab03458580ac1718eb4fc224b2d73febb77ca5b00607b878748de065R29-R30) [[2]](diffhunk://#diff-bbc9bd62ab03458580ac1718eb4fc224b2d73febb77ca5b00607b878748de065R52) [[3]](diffhunk://#diff-9b4784af469362b6fc4d35c7ce56272b28eb0ecac1639dc8717bd5039d849e5aR55-R59) [[4]](diffhunk://#diff-9b4784af469362b6fc4d35c7ce56272b28eb0ecac1639dc8717bd5039d849e5aR114-R143) [[5]](diffhunk://#diff-9b4784af469362b6fc4d35c7ce56272b28eb0ecac1639dc8717bd5039d849e5aR167-R179) [[6]](diffhunk://#diff-9b4784af469362b6fc4d35c7ce56272b28eb0ecac1639dc8717bd5039d849e5aL156-L169) [[7]](diffhunk://#diff-9b4784af469362b6fc4d35c7ce56272b28eb0ecac1639dc8717bd5039d849e5aL213-R304)
* Implemented progress notifications: handlers can now send progress updates back to the client using the new `ProgressSender` and `ServerNotification` types, with protocol-compliant message structures (`ProgressNotificationMessage`, etc.). [[1]](diffhunk://#diff-2f2e2f09f0556aedb0b94669791e0cfbb69cb3ffc68aee05be569611bf1dbaf5R1-R34) [[2]](diffhunk://#diff-f2fee9e8a8ea12448d568b8eda2d3df3ff695c71ddaa2d86bcffbec0f8e1588dR30-R112)

### Handler and API Ergonomics

* Updated the `ToolHandler` trait so that `call_tool` receives a `ProgressSender`, enabling tool implementations to send progress updates during execution.
* Added `tool_dispatch!`, `extract_required!`, and `extract_optional!` macros to simplify tool method dispatch and parameter extraction in handlers.

### Public API and Module Organization

* Reorganized and expanded public exports in `lib.rs` and added a `prelude` module for easier imports. [[1]](diffhunk://#diff-859349042dd5aca4223f1130359bc8cd5790333281b8e45f0c3db6716cb63742R2-R21) [[2]](diffhunk://#diff-10167e395dfec627f0463d2f7c1a03b573552834cdcb467933f9a11ce9afebe1R1-R5)

These changes collectively make the SDK more robust for interactive and long-running operations, providing a better user and developer experience.